### PR TITLE
chore(ui): make imagepopup look better

### DIFF
--- a/composeApp/shared/src/androidMain/kotlin/org/ballistic/dreamjournalai/shared/core/domain/VibratorRepository.kt
+++ b/composeApp/shared/src/androidMain/kotlin/org/ballistic/dreamjournalai/shared/core/domain/VibratorRepository.kt
@@ -9,6 +9,8 @@ import androidx.annotation.RequiresPermission
 actual interface VibratorUtil {
     @RequiresPermission(android.Manifest.permission.VIBRATE)
     actual fun triggerVibration()
+    @RequiresPermission(android.Manifest.permission.VIBRATE)
+    actual fun triggerVibrationSuccess()
     actual fun cancelVibration()
 }
 
@@ -27,6 +29,20 @@ class VibratorUtilImpl(
         } else {
             @Suppress("DEPRECATION")
             vibrator.vibrate(100L)
+        }
+    }
+
+    @RequiresPermission(android.Manifest.permission.VIBRATE)
+    override fun triggerVibrationSuccess() {
+        val vibrator = context.getSystemService(Context.VIBRATOR_SERVICE) as? Vibrator ?: return
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            vibrator.vibrate(
+                VibrationEffect.createPredefined(VibrationEffect.EFFECT_TICK)
+            )
+        } else {
+            @Suppress("DEPRECATION")
+            vibrator.vibrate(longArrayOf(0, 200, 100, 300), -1)
         }
     }
 

--- a/composeApp/shared/src/commonMain/kotlin/org/ballistic/dreamjournalai/shared/core/domain/VibratorRepository.kt
+++ b/composeApp/shared/src/commonMain/kotlin/org/ballistic/dreamjournalai/shared/core/domain/VibratorRepository.kt
@@ -2,5 +2,6 @@ package org.ballistic.dreamjournalai.shared.core.domain
 
 expect interface VibratorUtil {
     fun triggerVibration()
+    fun triggerVibrationSuccess()
     fun cancelVibration()
 }

--- a/composeApp/shared/src/commonMain/kotlin/org/ballistic/dreamjournalai/shared/dream_add_edit/domain/AddEditDreamEvent.kt
+++ b/composeApp/shared/src/commonMain/kotlin/org/ballistic/dreamjournalai/shared/dream_add_edit/domain/AddEditDreamEvent.kt
@@ -24,10 +24,11 @@ sealed class AddEditDreamEvent {
     data class AdAIResponseToggle(val value: Boolean) : AddEditDreamEvent()
 
     data class ClickGenerateAIImage(
-        val content: String,
+        val style: String,
         val cost: Int
     ) : AddEditDreamEvent()
     data class AdAIImageToggle(val value: Boolean) : AddEditDreamEvent()
+    data class OnImageStyleChanged(val style: ImageStyle) : AddEditDreamEvent()
 
     data class ClickGenerateAIAdvice(
         val content: String,
@@ -90,4 +91,7 @@ sealed class AddEditDreamEvent {
     data object OnCleared : AddEditDreamEvent()
 
     data object TriggerVibration : AddEditDreamEvent()
+    data object TriggerVibrationSuccess : AddEditDreamEvent()
+    data object ResetNewImageGeneratedFlag : AddEditDreamEvent()
+    data class SetStartAnimation(val value: Boolean) : AddEditDreamEvent()
 }

--- a/composeApp/shared/src/commonMain/kotlin/org/ballistic/dreamjournalai/shared/dream_add_edit/domain/ImageStyle.kt
+++ b/composeApp/shared/src/commonMain/kotlin/org/ballistic/dreamjournalai/shared/dream_add_edit/domain/ImageStyle.kt
@@ -1,0 +1,39 @@
+package org.ballistic.dreamjournalai.shared.dream_add_edit.domain
+
+enum class ImageStyle(
+    val displayName: String,
+    val promptAffix: String,
+    val image: String
+) {
+    VIBRANT(
+        "Vibrant",
+        ", ultra-vibrant colors, dreamy atmosphere, painterly lighting, high detail, rich fantasy tones",
+        "https://firebasestorage.googleapis.com/v0/b/dream-journal-ai.appspot.com/o/DreamStyleImages%2FVibrantDream.png?alt=media&token=8d16286e-833b-40e5-a219-d3f1e488c59e"
+    ),
+
+    REALISTIC(
+        "Realistic",
+        ", semi-photorealistic, cinematic lighting, ultra-detailed textures, 8k clarity, breathtaking natural realism",
+        "https://firebasestorage.googleapis.com/v0/b/dream-journal-ai.appspot.com/o/DreamStyleImages%2FWormwholeWhale.png?alt=media&token=529c054c-c5b7-4b31-941c-b7bfcb8314ac"
+    ),
+    ANIME(
+        "Anime",
+        ", anime style, Studio Ghibli aesthetic, soft lighting, whimsical scenery, hand-painted vibe, vibrant yet gentle colors",
+        "https://firebasestorage.googleapis.com/v0/b/dream-journal-ai.appspot.com/o/DreamStyleImages%2FGhibliDream.png?alt=media&token=ea5fb2f4-c046-4cfe-982a-297798f27551"
+    ),
+    FANTASY(
+        "Fantasy",
+        ", dreamy fantasy aesthetic, glowing atmosphere, enchanted landscapes, magical lighting, epic whimsical scenery, storybook wonder",
+        "https://firebasestorage.googleapis.com/v0/b/dream-journal-ai.appspot.com/o/DreamStyleImages%2FFantasyDream.png?alt=media&token=5d3149ea-500d-4c72-a55c-485f05656158"
+    ),
+    NIGHTMARE(
+        "Nightmare",
+        ", dark horror aesthetic, eerie atmosphere, foggy shadows, unsettling tension, creepy lighting, haunting scenery, gothic mood",
+        "https://firebasestorage.googleapis.com/v0/b/dream-journal-ai.appspot.com/o/DreamStyleImages%2FScaryDream.png?alt=media&token=4d49af92-8263-4fb3-86d4-aa541ec4eb90"
+    ),
+    SCI_FI(
+        "Sci-Fi",
+        ", futuristic sci-fi aesthetic, neon glow, sleek technology, cosmic atmosphere, advanced structures, cinematic sci-fi lighting, otherworldly landscapes",
+        "https://firebasestorage.googleapis.com/v0/b/dream-journal-ai.appspot.com/o/DreamStyleImages%2FSciFiDream.png?alt=media&token=29bf94df-ae7d-4f86-9b69-1d47dafe2ebd"
+    )
+}

--- a/composeApp/shared/src/commonMain/kotlin/org/ballistic/dreamjournalai/shared/dream_add_edit/presentation/components/DreamInterpretationPopUp.kt
+++ b/composeApp/shared/src/commonMain/kotlin/org/ballistic/dreamjournalai/shared/dream_add_edit/presentation/components/DreamInterpretationPopUp.kt
@@ -1,39 +1,22 @@
 package org.ballistic.dreamjournalai.shared.dream_add_edit.presentation.components
 
 import androidx.compose.animation.animateContentSize
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.RadioButton
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import dreamjournalai.composeapp.shared.generated.resources.Res
-import dreamjournalai.composeapp.shared.generated.resources.advanced_ai
-import dreamjournalai.composeapp.shared.generated.resources.standard_ai
 import org.ballistic.dreamjournalai.shared.theme.OriginalXmlColors.BrighterWhite
 import org.ballistic.dreamjournalai.shared.theme.OriginalXmlColors.LightBlack
 import org.ballistic.dreamjournalai.shared.theme.OriginalXmlColors.White
 import org.ballistic.dreamjournalai.shared.core.components.DreamTokenLayout
-import org.jetbrains.compose.resources.stringResource
+import org.ballistic.dreamjournalai.shared.theme.OriginalXmlColors
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -45,81 +28,88 @@ fun DreamInterpretationPopUp(
     onClickOutside: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    var state by remember { mutableStateOf(true) }
-    var amount by remember { mutableIntStateOf(0) }
+    var selectedIndex by remember { mutableIntStateOf(0) }
+    val options = listOf("Standard AI", "Advanced AI")
+    val amount = selectedIndex
+    val sheetState = rememberModalBottomSheetState(
+        skipPartiallyExpanded = true
+    )
+
     ModalBottomSheet(
         modifier = modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(topStart = 8.dp, topEnd = 8.dp),
+        sheetState = sheetState,
+        shape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp),
         onDismissRequest = {
             onClickOutside()
         },
         content = {
-                Column(
-                    modifier = modifier
+            Column(
+                modifier = modifier
+                    .fillMaxWidth()
+                    .background(LightBlack)
+                    .verticalScroll(rememberScrollState())
+                    .padding(bottom = 16.dp)
+                    .animateContentSize(),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier
                         .fillMaxWidth()
-                        .verticalScroll(rememberScrollState())
-                        .padding(16.dp, 0.dp, 16.dp, 16.dp)
-                        .animateContentSize(),
-                    horizontalAlignment = Alignment.CenterHorizontally
+                        .padding(horizontal = 24.dp)
+                        .padding(top = 8.dp)
                 ) {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                    ){
-                        Text(
-                            text = title,
-                            style = MaterialTheme.typography.headlineMedium,
-                            color = BrighterWhite,
-                            modifier = Modifier.padding(8.dp, 8.dp, 8.dp, 8.dp)
-                        )
-                        DreamTokenLayout(
-                            totalDreamTokens = dreamTokens,
-                        )
-                    }
-
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        modifier = Modifier.selectableGroup()
-                    ) {
-                        RadioButton(
-                            selected = state,
-                            onClick = {
-                                state = true
-                                amount = 0
-                                      },
-                            modifier = Modifier.semantics { contentDescription = "Localized Description" }
-                        )
-
-                        //standard ai
-                        Text(text = stringResource(Res.string.standard_ai), color = White)
-
-                        Spacer(modifier = Modifier.weight(1f))
-
-                        RadioButton(
-                            selected = !state,
-                            onClick = {
-                                state = false
-                                amount = 1
-                                      },
-                            modifier = Modifier.semantics { contentDescription = "Localized Description" }
-                        )
-                        //Advanced AI
-                        Text(
-                            text = stringResource(Res.string.advanced_ai),
-                            color = White,
-                            modifier = Modifier.padding(end = 8.dp)
-                        )
-                    }
-                    AdTokenLayout(
-                        isAdButtonVisible = amount <= 1 && amount != 0,
-                        onAdClick = {
-                            onAdClick() // Use the lambda correctly
-                        },
-                        onDreamTokenClick = {
-                            onDreamTokenClick(amount) // Use the lambda correctly
-                        },
-                        amount = amount
+                    Spacer(modifier = Modifier.weight(1f))
+                    Text(
+                        text = title,
+                        style = MaterialTheme.typography.headlineSmall,
+                        color = White,
                     )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    DreamTokenLayout(
+                        totalDreamTokens = dreamTokens
+                    )
+                    Spacer(modifier = Modifier.weight(1f))
                 }
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                SingleChoiceSegmentedButtonRow(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 24.dp)
+                ) {
+                    options.forEachIndexed { index, label ->
+                        SegmentedButton(
+                            shape = SegmentedButtonDefaults.itemShape(
+                                index = index,
+                                count = options.size
+                            ),
+                            onClick = { selectedIndex = index },
+                            selected = index == selectedIndex,
+                            label = { Text(label, style = MaterialTheme.typography.labelMedium) },
+                            colors = SegmentedButtonDefaults.colors(
+                                activeContainerColor = OriginalXmlColors.SkyBlue.copy(alpha = 0.8f),
+                                activeContentColor = White,
+                                inactiveContainerColor = Color.DarkGray.copy(alpha = 0.5f),
+                                inactiveContentColor = White.copy(alpha = 0.7f),
+                                activeBorderColor = OriginalXmlColors.SkyBlue
+                            )
+                        )
+                    }
+                }
+                Spacer(modifier = Modifier.height(24.dp))
+                AdTokenLayout(
+                    isAdButtonVisible = amount == 1,
+                    onAdClick = {
+                        onAdClick()
+                    },
+                    onDreamTokenClick = {
+                        onDreamTokenClick(amount)
+                    },
+                    amount = amount
+                )
+            }
         },
         containerColor = LightBlack
     )

--- a/composeApp/shared/src/commonMain/kotlin/org/ballistic/dreamjournalai/shared/dream_add_edit/presentation/components/GenerateButtons.kt
+++ b/composeApp/shared/src/commonMain/kotlin/org/ballistic/dreamjournalai/shared/dream_add_edit/presentation/components/GenerateButtons.kt
@@ -194,14 +194,13 @@ fun AdTokenLayout(
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(),
+            .padding(horizontal = 24.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center
     ) {
-        Spacer(modifier = Modifier.height(8.dp))
         DreamTokenGenerateButton(onClick = { onDreamTokenClick(amount) }, amount = amount)
         if (isAdButtonVisible) {
-            Spacer(modifier = Modifier.height(16.dp))
+            Spacer(modifier = Modifier.height(12.dp))
             WatchAdButton(onClick = { onAdClick() })
         }
     }
@@ -209,34 +208,35 @@ fun AdTokenLayout(
 
 @Composable
 fun WatchAdButton(
-    onClick: () -> Unit = {}
+    onClick: () -> Unit,
 ) {
     val lastClickTime = remember { mutableLongStateOf(0L) }
     Button(
-        onClick = singleClick(lastClickTime) {onClick()},
+        onClick = singleClick(lastClickTime) { onClick() },
         modifier = Modifier
-            .fillMaxWidth(),
-        colors = ButtonDefaults.buttonColors(containerColor = RedOrange),
+            .fillMaxWidth()
+            .height(50.dp),
+        shape = RoundedCornerShape(12.dp),
+        colors = ButtonDefaults.buttonColors(containerColor = RedOrange.copy(alpha = 0.8f)),
     ) {
-
-        Icon(
-            painter = painterResource(Res.drawable.baseline_smart_display_24),
-            contentDescription = stringResource(Res.string.watch_ad),
-            modifier = Modifier
-                .size(36.dp),
-            tint = White,
-        )
-        Spacer(modifier = Modifier.weight(1f))
-        Text(
-            text = stringResource(Res.string.watch_ad),
-            modifier = Modifier
-                .padding(4.dp),
-            color = Color.White,
-            style = MaterialTheme.typography.titleMedium,
-            fontWeight = FontWeight.Bold
-        )
-        Spacer(modifier = Modifier.weight(1f))
-        Spacer(modifier = Modifier.size(36.dp))
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.Center
+        ) {
+            Icon(
+                painter = painterResource(Res.drawable.baseline_smart_display_24),
+                contentDescription = stringResource(Res.string.watch_ad),
+                modifier = Modifier.size(24.dp),
+                tint = White,
+            )
+            Spacer(modifier = Modifier.size(8.dp))
+            Text(
+                text = stringResource(Res.string.watch_ad),
+                color = Color.White,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold
+            )
+        }
     }
 }
 
@@ -245,50 +245,31 @@ fun DreamTokenGenerateButton(
     onClick: () -> Unit,
     amount: Int
 ) {
-    val amountText = if (amount == 0) "" else amount.toString()
+    val amountText = if (amount == 0) "Free" else "$amount"
     Button(
         onClick = onClick,
         modifier = Modifier
-            .fillMaxWidth(),
-        colors = ButtonDefaults.buttonColors(containerColor = SkyBlue),
+            .fillMaxWidth()
+            .height(50.dp),
+        shape = RoundedCornerShape(12.dp),
+        colors = ButtonDefaults.buttonColors(containerColor = SkyBlue.copy(alpha = 0.8f)),
     ) {
-        Image(
-            painter = painterResource(Res.drawable.dream_token),
-            contentDescription = "DreamToken",
-            modifier = Modifier
-                .size(40.dp)
-        )
-
-        Text(
-            text = amountText,
-            modifier = Modifier
-                .padding(4.dp),
-            color = Color.White,
-            style = MaterialTheme.typography.titleMedium,
-        )
-        Spacer(modifier = Modifier.weight(1f))
-        Text(
-            text = if (amount == 0) "Free" else "DreamToken",
-            modifier = Modifier
-                .padding(4.dp),
-            color = Color.White,
-            style = MaterialTheme.typography.titleMedium,
-            fontWeight = FontWeight.Bold
-        )
-        Spacer(modifier = Modifier.weight(1f))
-        Icon(
-            painter = painterResource(Res.drawable.dream_token),
-            contentDescription = "DreamToken",
-            modifier = Modifier
-                .size(40.dp),
-            tint = Color.Transparent
-        )
-        Text(
-            text = amountText,
-            modifier = Modifier
-                .padding(4.dp),
-            color = Color.Transparent,
-            style = MaterialTheme.typography.titleMedium,
-        )
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.Center
+        ) {
+            Image(
+                painter = painterResource(Res.drawable.dream_token),
+                contentDescription = "DreamToken",
+                modifier = Modifier.size(30.dp)
+            )
+            Spacer(modifier = Modifier.size(8.dp))
+            Text(
+                text = "Use $amountText Dream Tokens",
+                color = Color.White,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold
+            )
+        }
     }
 }

--- a/composeApp/shared/src/commonMain/kotlin/org/ballistic/dreamjournalai/shared/dream_add_edit/presentation/components/QuestionAIGenerationBottomSheet.kt
+++ b/composeApp/shared/src/commonMain/kotlin/org/ballistic/dreamjournalai/shared/dream_add_edit/presentation/components/QuestionAIGenerationBottomSheet.kt
@@ -2,37 +2,20 @@ package org.ballistic.dreamjournalai.shared.dream_add_edit.presentation.componen
 
 import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.OutlinedTextFieldDefaults
-import androidx.compose.material3.RadioButton
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import org.ballistic.dreamjournalai.shared.dream_add_edit.domain.AddEditDreamEvent
 import org.ballistic.dreamjournalai.shared.dream_add_edit.presentation.viewmodel.AIType
 import org.ballistic.dreamjournalai.shared.dream_add_edit.presentation.viewmodel.AddEditDreamState
+import org.ballistic.dreamjournalai.shared.theme.OriginalXmlColors
 import org.ballistic.dreamjournalai.shared.theme.OriginalXmlColors.LightBlack
 import org.ballistic.dreamjournalai.shared.theme.OriginalXmlColors.White
 import org.ballistic.dreamjournalai.shared.core.components.DreamTokenLayout
@@ -47,34 +30,46 @@ fun QuestionAIGenerationBottomSheet(
     onClickOutside: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    var state by remember { mutableStateOf(true) }
-    var amount by remember { mutableIntStateOf(0) }
+    var selectedIndex by remember { mutableIntStateOf(0) }
+    val options = listOf("Standard AI", "Advanced AI")
+    val amount = selectedIndex
+    val sheetState = rememberModalBottomSheetState(
+        skipPartiallyExpanded = true
+    )
+
     ModalBottomSheet(
         modifier = modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(topStart = 8.dp, topEnd = 8.dp),
+        sheetState = sheetState,
+        shape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp),
         onDismissRequest = onClickOutside,
         content = {
             Column(
                 modifier = modifier
                     .fillMaxWidth()
-                    .background(Color.Transparent)
+                    .background(LightBlack)
                     .verticalScroll(rememberScrollState())
-                    .padding(16.dp, 0.dp, 16.dp, 16.dp)
+                    .padding(bottom = 16.dp)
                     .animateContentSize(),
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 24.dp)
+                        .padding(top = 8.dp)
                 ) {
+                    Spacer(modifier = Modifier.weight(1f))
                     Text(
                         text = "Dream Question",
-                        style = MaterialTheme.typography.headlineMedium,
+                        style = MaterialTheme.typography.headlineSmall,
                         color = White,
-                        modifier = Modifier.padding(8.dp)
                     )
+                    Spacer(modifier = Modifier.width(8.dp))
                     DreamTokenLayout(
-                        totalDreamTokens = addEditDreamState.dreamTokens,
+                        totalDreamTokens = addEditDreamState.dreamTokens
                     )
+                    Spacer(modifier = Modifier.weight(1f))
                 }
                 OutlinedTextField(
                     value = addEditDreamState.aiStates[AIType.QUESTION_ANSWER]?.question ?: "",
@@ -89,51 +84,41 @@ fun QuestionAIGenerationBottomSheet(
                     },
                     modifier = modifier
                         .fillMaxWidth()
-                        .padding(8.dp, 8.dp, 8.dp, 16.dp),
+                        .padding(16.dp, 8.dp, 16.dp, 16.dp),
                     textStyle = MaterialTheme.typography.bodyLarge,
                     singleLine = false,
                     maxLines = 3,
                     colors = OutlinedTextFieldDefaults.colors()
                 )
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    modifier = Modifier.selectableGroup()
+                SingleChoiceSegmentedButtonRow(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 24.dp)
                 ) {
-                    RadioButton(
-                        selected = state,
-                        onClick = {
-                            state = true
-                            amount = 0
-                        },
-                        modifier = Modifier.semantics { contentDescription = "Localized Description" }
-                    )
-
-                   Text(
-                        text = "Standard AI",
-                        color = White
-                    )
-
-                    Spacer(modifier = Modifier.weight(1f))
-
-                    RadioButton(
-                        selected = !state,
-                        onClick = {
-                            state = false
-                            amount = 1
-                        },
-                        modifier = Modifier.semantics { contentDescription = "Localized Description" }
-                    )
-
-                    Text(
-                        text = "Advanced AI",
-                        color = White,
-                        modifier = Modifier.padding(end = 8.dp)
-                    )
+                    options.forEachIndexed { index, label ->
+                        SegmentedButton(
+                            shape = SegmentedButtonDefaults.itemShape(
+                                index = index,
+                                count = options.size
+                            ),
+                            onClick = { selectedIndex = index },
+                            selected = index == selectedIndex,
+                            label = { Text(label, style = MaterialTheme.typography.labelMedium) },
+                            colors = SegmentedButtonDefaults.colors(
+                                activeContainerColor = OriginalXmlColors.SkyBlue.copy(alpha = 0.8f),
+                                activeContentColor = White,
+                                inactiveContainerColor = Color.DarkGray.copy(alpha = 0.5f),
+                                inactiveContentColor = White.copy(alpha = 0.7f),
+                                activeBorderColor = OriginalXmlColors.SkyBlue
+                            )
+                        )
+                    }
                 }
+                Spacer(modifier = Modifier.height(24.dp))
                 AdTokenLayout(
                     isAdButtonVisible = amount == 1,
                     onAdClick = { onAdClick() },
-                    onDreamTokenClick = { onDreamTokenClick(it) },
+                    onDreamTokenClick = { onDreamTokenClick(amount) },
                     amount = amount
                 )
             }

--- a/composeApp/shared/src/commonMain/kotlin/org/ballistic/dreamjournalai/shared/dream_add_edit/presentation/pages/AIPage/AIPage.kt
+++ b/composeApp/shared/src/commonMain/kotlin/org/ballistic/dreamjournalai/shared/dream_add_edit/presentation/pages/AIPage/AIPage.kt
@@ -24,7 +24,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerState
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.material3.Button
@@ -118,7 +117,7 @@ fun SharedTransitionScope.AIPage(
         AIPage.IMAGE -> {
             ImageGenerationPopUp(
                 addEditDreamState = addEditDreamState,
-                onDreamTokenClick = { amount ->
+                onDreamTokenClick = { amount, style ->
                     onAddEditDreamEvent(AddEditDreamEvent.SetAIPage(null))
                     if (dreamTokens < amount) {
                         scope.launch {
@@ -136,7 +135,7 @@ fun SharedTransitionScope.AIPage(
                         scope.launch {
                             onAddEditDreamEvent(
                                 AddEditDreamEvent.ClickGenerateAIImage(
-                                    content = textFieldState.text.toString(),
+                                    style = style,
                                     cost = amount
                                 )
                             )
@@ -156,6 +155,9 @@ fun SharedTransitionScope.AIPage(
                 onClickOutside = {
                     onAddEditDreamEvent(AddEditDreamEvent.SetAIPage(null))
                 },
+                onImageStyleChange = {
+                    onAddEditDreamEvent(AddEditDreamEvent.OnImageStyleChanged(it))
+                }
             )
         }
 
@@ -399,7 +401,7 @@ fun SharedTransitionScope.AIPage(
             onRewardEarned = {
                 onAddEditDreamEvent(
                     AddEditDreamEvent.ClickGenerateAIImage(
-                        content = textFieldState.text.toString(),
+                        style = addEditDreamState.imageStyle.promptAffix,
                         cost = 0
                     )
                 )
@@ -627,19 +629,20 @@ fun SharedTransitionScope.AIPage(
                 )
             }
         }
-        Column(
+        // Replace scrolling Column with a Box that fills remaining space
+        Box(
             modifier = Modifier
                 .clip(RoundedCornerShape(10.dp))
                 .background(LightBlack.copy(alpha = 0.7f))
-                .weight(1f),
-            horizontalAlignment = Alignment.CenterHorizontally
+                .weight(1f)
+                .fillMaxWidth(),
         ) {
 
             HorizontalPager(
                 state = pagerState2,
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .align(Alignment.CenterHorizontally)
+                    .fillMaxSize()
+                    .align(Alignment.Center)
                     .background(
                         color = LightBlack.copy(alpha = 0.0f)
                     ),
@@ -676,7 +679,6 @@ fun SharedTransitionScope.AIPage(
                     }
                 )
             }
-            Spacer(modifier = Modifier.weight(1f))
         }
 
         Box(

--- a/composeApp/shared/src/commonMain/kotlin/org/ballistic/dreamjournalai/shared/dream_add_edit/presentation/pages/AIPage/AISubPages/AISubPages.kt
+++ b/composeApp/shared/src/commonMain/kotlin/org/ballistic/dreamjournalai/shared/dream_add_edit/presentation/pages/AIPage/AISubPages/AISubPages.kt
@@ -1,32 +1,30 @@
 package org.ballistic.dreamjournalai.shared.dream_add_edit.presentation.pages.AIPage.AISubPages
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.AnimatedVisibilityScope
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionScope
-import androidx.compose.animation.core.InfiniteTransition
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.LinearOutSlowInEasing
 import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.aspectRatio
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme.typography
 import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableLongStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.FilterQuality
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -37,18 +35,20 @@ import coil3.compose.AsyncImagePainter
 import coil3.compose.LocalPlatformContext
 import coil3.compose.rememberAsyncImagePainter
 import coil3.request.ImageRequest
-import coil3.request.crossfade
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import org.ballistic.dreamjournalai.shared.core.components.TypewriterText
 import org.ballistic.dreamjournalai.shared.dream_add_edit.domain.AIPageType
+import org.ballistic.dreamjournalai.shared.dream_add_edit.domain.AddEditDreamEvent
 import org.ballistic.dreamjournalai.shared.dream_add_edit.presentation.components.ArcRotationAnimation
+import org.ballistic.dreamjournalai.shared.dream_add_edit.presentation.components.UniversalButton
 import org.ballistic.dreamjournalai.shared.dream_add_edit.presentation.viewmodel.AIState
 import org.ballistic.dreamjournalai.shared.dream_add_edit.presentation.viewmodel.AIType
 import org.ballistic.dreamjournalai.shared.dream_add_edit.presentation.viewmodel.AddEditDreamState
 import org.ballistic.dreamjournalai.shared.dream_store.presentation.store_screen.components.singleClick
+import org.ballistic.dreamjournalai.shared.theme.OriginalXmlColors
 import org.ballistic.dreamjournalai.shared.theme.OriginalXmlColors.BrighterWhite
 import org.ballistic.dreamjournalai.shared.theme.OriginalXmlColors.White
-import org.ballistic.dreamjournalai.shared.core.components.TypewriterText
-import org.ballistic.dreamjournalai.shared.dream_add_edit.domain.AddEditDreamEvent
-import org.ballistic.dreamjournalai.shared.dream_add_edit.presentation.components.UniversalButton
 
 
 @OptIn(ExperimentalSharedTransitionApi::class)
@@ -113,20 +113,36 @@ fun StandardAIPageLayout(
     onAddEditEvent: (AddEditDreamEvent) -> Unit,
     snackBarState: () -> Unit,
 ) {
+    val (progress, showLoading, _) = rememberTimedProgress(
+        isLoading = aiContent.isLoading,
+        contentType = contentType,
+    )
 
-    if (aiContent.isLoading) {
-        Box(
+    if (showLoading) {
+        Column(
             modifier = Modifier
-                .fillMaxWidth()
-                .aspectRatio(1f)
+                .fillMaxSize()
                 .padding(16.dp, 0.dp, 16.dp, 16.dp)
                 .clip(RoundedCornerShape(10.dp)),
-            contentAlignment = Alignment.Center
         ) {
-            ArcRotationAnimation()
+            // Arc at top with 1:1 ratio
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .aspectRatio(1f),
+                contentAlignment = Alignment.Center
+            ) { ArcRotationAnimation() }
+            // Spacer to push progress bar to bottom
+            Spacer(modifier = Modifier.weight(1f))
+            LoadingProgressBar(
+                progress = progress,
+                color = colorFor(contentType),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 4.dp)
+            )
         }
-    }
-    if (aiContent.response.isNotEmpty() && !aiContent.isLoading) {
+    } else if (aiContent.response.isNotEmpty()) {
         Column(
             horizontalAlignment = Alignment.Start,
             modifier = Modifier
@@ -148,9 +164,7 @@ fun StandardAIPageLayout(
                 useMarkdown = true
             )
         }
-    }
-
-    if (aiContent.response.isEmpty() && !aiContent.isLoading) {
+    } else {
         Box(
             modifier = Modifier
                 .fillMaxWidth()
@@ -186,66 +200,95 @@ fun SharedTransitionScope.AIPainterPage(
     onImageClick: () -> Unit
 ) {
     val imageState = addEditDreamState.aiStates[AIType.IMAGE]!!
-    val painter = rememberAsyncImagePainter(
-        model = imageState.response,
-        filterQuality = FilterQuality.Low
+    val painter = rememberAsyncImagePainter(model = imageState.response)
+    val painterState by painter.state.collectAsState()
+
+    val (progress, showLoading, _) = rememberTimedProgress(
+        isLoading = imageState.isLoading,
+        contentType = AIPageType.PAINTER,
+        onFullyFinished = {
+            if (addEditDreamState.isNewImageGenerated) {
+                onAddEditEvent(AddEditDreamEvent.SetStartAnimation(true))
+            }
+        }
     )
 
-    val cont =  LocalPlatformContext.current
-    val painterState by painter.state.collectAsState() // Collect the StateFlow into State
+    val scale = remember { Animatable(if (addEditDreamState.isNewImageGenerated) 0.8f else 1f) }
+    val alpha = remember { Animatable(if (addEditDreamState.isNewImageGenerated) 0f else 1f) }
 
-    if (imageState.isLoading) {
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .aspectRatio(1f)
-                .padding(8.dp)
-                .clip(RoundedCornerShape(10.dp)),
-            contentAlignment = Alignment.Center
-        ) {
-            ArcRotationAnimation()
+    LaunchedEffect(addEditDreamState.startAnimation) {
+        if (addEditDreamState.startAnimation) {
+            alpha.snapTo(0f)
+            scale.snapTo(0.9f)
+            launch {
+                scale.animateTo(1f, animationSpec = tween(600, easing = LinearOutSlowInEasing))
+            }
+            launch {
+                alpha.animateTo(1f, animationSpec = tween(600, easing = LinearOutSlowInEasing))
+            }
+            delay(450)
+            onAddEditEvent(AddEditDreamEvent.TriggerVibrationSuccess)
+            onAddEditEvent(AddEditDreamEvent.ResetNewImageGeneratedFlag)
+            onAddEditEvent(AddEditDreamEvent.SetStartAnimation(false))
         }
     }
 
-    if (imageState.response != "" && !imageState.isLoading) {
+    if (showLoading) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp, 0.dp, 16.dp, 16.dp)
+                .clip(RoundedCornerShape(10.dp)),
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .aspectRatio(1f),
+                contentAlignment = Alignment.Center
+            ) { ArcRotationAnimation() }
+            Spacer(modifier = Modifier.weight(1f))
+            LoadingProgressBar(
+                progress = progress,
+                color = colorFor(AIPageType.PAINTER),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 4.dp)
+            )
+        }
+    } else if (imageState.response.isNotEmpty()) {
         Box(
             modifier = Modifier
                 .fillMaxWidth()
                 .aspectRatio(1f)
                 .padding(8.dp)
-                .clip(RoundedCornerShape(8.dp)),
+                .clip(RoundedCornerShape(8.dp))
+                .graphicsLayer {
+                    scaleX = scale.value
+                    scaleY = scale.value
+                    this.alpha = alpha.value
+                },
             contentAlignment = Alignment.Center
         ) {
-            if (painterState is AsyncImagePainter.State.Loading) {
-               ArcRotationAnimation()
-            }
             AsyncImage(
-                model =  ImageRequest.Builder(cont)
+                model = ImageRequest.Builder(LocalPlatformContext.current)
                     .data(imageState.response)
-                    .crossfade(true)
-                    .placeholderMemoryCacheKey("image/${imageState.response}") //  same key as shared element key
-                    .memoryCacheKey("image/${imageState.response}") // same key as shared element key
+                    .placeholderMemoryCacheKey("image/${imageState.response}")
+                    .memoryCacheKey("image/${imageState.response}")
                     .build(),
                 contentDescription = "AI Generated Image",
                 modifier = Modifier
                     .fillMaxSize()
                     .clip(RoundedCornerShape(10.dp))
-                    .clickable {
-                        onImageClick()
-                    }
+                    .clickable(onClick = onImageClick)
                     .sharedElement(
                         rememberSharedContentState(key = "image/${imageState.response}"),
                         animatedVisibilityScope = animatedVisibilityScope,
-                        boundsTransform = { _, _ ->
-                            tween(500)
-                        }
+                        boundsTransform = { _, _ -> tween(500) }
                     ),
                 contentScale = ContentScale.Crop
             )
         }
-    }
-
-    if (imageState.response == "" && !imageState.isLoading) {
+    } else {
         Box(
             modifier = Modifier
                 .fillMaxWidth()
@@ -277,21 +320,34 @@ fun AIQuestionPage(
 ) {
     val questionState = addEditDreamState.aiStates[AIType.QUESTION_ANSWER]!!
 
-    // Loading animation while AI is generating response
-    if (questionState.isLoading) {
-        Box(
+    val (progress, showLoading, _) = rememberTimedProgress(
+        isLoading = questionState.isLoading,
+        contentType = AIPageType.QUESTION
+    )
+
+    if (showLoading) {
+        Column(
             modifier = Modifier
-                .fillMaxWidth()
-                .aspectRatio(1f)
+                .fillMaxSize()
                 .padding(16.dp, 0.dp, 16.dp, 16.dp)
                 .clip(RoundedCornerShape(10.dp)),
-            contentAlignment = Alignment.Center
         ) {
-            ArcRotationAnimation()
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .aspectRatio(1f),
+                contentAlignment = Alignment.Center
+            ) { ArcRotationAnimation() }
+            Spacer(modifier = Modifier.weight(1f))
+            LoadingProgressBar(
+                progress = progress,
+                color = colorFor(AIPageType.QUESTION),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 4.dp)
+            )
         }
-    }
-
-    if (questionState.response != "" && !questionState.isLoading) {
+    } else if (questionState.response.isNotEmpty()) {
         Column(
             horizontalAlignment = Alignment.Start,
             modifier = Modifier
@@ -311,7 +367,6 @@ fun AIQuestionPage(
                 modifier = Modifier.padding(16.dp, 0.dp, 16.dp, 0.dp),
                 textAlign = TextAlign.Center
             )
-
             TypewriterText(
                 text = questionState.response.trim(),
                 style = typography.bodyMedium,
@@ -320,18 +375,15 @@ fun AIQuestionPage(
                 color = White,
             )
         }
-    }
-
-    // Button to ask a new question
-    Box(
-        modifier = Modifier
-            .fillMaxWidth()
-            .aspectRatio(1f)
-            .padding(16.dp)
-            .clip(RoundedCornerShape(8.dp)),
-        contentAlignment = Alignment.Center
-    ) {
-        if (questionState.response == "" && !questionState.isLoading) {
+    } else {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .aspectRatio(1f)
+                .padding(16.dp)
+                .clip(RoundedCornerShape(8.dp)),
+            contentAlignment = Alignment.Center
+        ) {
             UniversalButton(
                 textFieldState = textFieldState,
                 size = 160.dp,
@@ -344,4 +396,116 @@ fun AIQuestionPage(
             )
         }
     }
+}
+
+private fun colorFor(contentType: AIPageType): Color {
+    return when (contentType) {
+        AIPageType.PAINTER -> OriginalXmlColors.SkyBlue
+        AIPageType.EXPLANATION -> OriginalXmlColors.Purple
+        AIPageType.ADVICE -> OriginalXmlColors.Yellow
+        AIPageType.QUESTION -> OriginalXmlColors.RedOrange
+        AIPageType.STORY -> OriginalXmlColors.LighterYellow
+        AIPageType.MOOD -> OriginalXmlColors.Green
+    }
+}
+
+@Composable
+private fun LoadingProgressBar(
+    progress: Float,
+    color: Color,
+    modifier: Modifier = Modifier,
+) {
+    val pct = (progress * 100).coerceIn(0f, 100f)
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(28.dp)
+            .clip(RoundedCornerShape(20.dp))
+            .background(
+                Brush.linearGradient(
+                    listOf(
+                        Color.White.copy(alpha = 0.12f),
+                        Color.White.copy(alpha = 0.06f)
+                    )
+                )
+            )
+            .border(
+                width = 1.dp,
+                color = Color.White.copy(alpha = 0.18f),
+                shape = RoundedCornerShape(20.dp)
+            )
+            .padding(horizontal = 12.dp, vertical = 6.dp),
+        contentAlignment = Alignment.CenterStart
+    ) {
+        Box(
+            modifier = Modifier
+                .matchParentSize()
+                .clip(RoundedCornerShape(20.dp))
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxHeight()
+                    .fillMaxWidth(progress)
+                    .clip(RoundedCornerShape(16.dp))
+                    .background(
+                        Brush.horizontalGradient(
+                            listOf(
+                                color.copy(alpha = 0.9f),
+                                color.copy(alpha = 0.5f)
+                            )
+                        )
+                    )
+            )
+        }
+        Text(
+            text = "${pct.toInt()}%",
+            color = Color.White,
+            style = typography.labelMedium.copy(fontWeight = FontWeight.Bold),
+            modifier = Modifier.align(Alignment.Center)
+        )
+    }
+}
+
+@Composable
+private fun rememberTimedProgress(
+    isLoading: Boolean,
+    contentType: AIPageType,
+    onFullyFinished: () -> Unit = {}
+): Triple<Float, Boolean, Boolean> {
+    val progressAnim = remember { Animatable(0f) }
+    var show by remember { mutableStateOf(false) }
+    var isAnimationFinished by remember { mutableStateOf(false) }
+
+    val (durationMs, bufferCap) = when (contentType) {
+        AIPageType.PAINTER -> 30_000L to 0.95f
+        else -> 10_000L to 0.97f
+    }
+
+    LaunchedEffect(isLoading) {
+        if (isLoading) {
+            show = true
+            isAnimationFinished = false
+            progressAnim.snapTo(0f)
+            progressAnim.animateTo(
+                targetValue = bufferCap,
+                animationSpec = tween(
+                    durationMillis = durationMs.toInt(),
+                    easing = LinearEasing
+                )
+            )
+        } else {
+            if (show) {
+                progressAnim.animateTo(
+                    targetValue = 1f,
+                    animationSpec = tween(500)
+                )
+                delay(250)
+                show = false
+                isAnimationFinished = true
+                onFullyFinished()
+            }
+        }
+    }
+
+    return Triple(progressAnim.value, show, isAnimationFinished)
 }

--- a/composeApp/shared/src/commonMain/kotlin/org/ballistic/dreamjournalai/shared/dream_symbols/presentation/components/BuySymbolBottomSheet.kt
+++ b/composeApp/shared/src/commonMain/kotlin/org/ballistic/dreamjournalai/shared/dream_symbols/presentation/components/BuySymbolBottomSheet.kt
@@ -70,6 +70,7 @@ fun BuySymbolBottomSheet(
                     onDreamTokenClick = {
                         onDreamTokenClick()
                     },
+
                     amount = amount
                 )
             }

--- a/composeApp/shared/src/iosMain/kotlin/org/ballistic/dreamjournalai/shared/core/domain/VibratorRepository.kt
+++ b/composeApp/shared/src/iosMain/kotlin/org/ballistic/dreamjournalai/shared/core/domain/VibratorRepository.kt
@@ -2,9 +2,12 @@ package org.ballistic.dreamjournalai.shared.core.domain
 
 import platform.UIKit.UIImpactFeedbackGenerator
 import platform.UIKit.UIImpactFeedbackStyle
+import platform.UIKit.UINotificationFeedbackGenerator
+import platform.UIKit.UINotificationFeedbackType
 
 actual interface VibratorUtil {
     actual fun triggerVibration()
+    actual fun triggerVibrationSuccess()
     actual fun cancelVibration()
 }
 
@@ -17,6 +20,12 @@ class VibratorUtilImpl : VibratorUtil {
         )
         impactGenerator.prepare()
         impactGenerator.impactOccurred()
+    }
+
+    override fun triggerVibrationSuccess() {
+        val notificationGenerator = UINotificationFeedbackGenerator()
+        notificationGenerator.prepare()
+        notificationGenerator.notificationOccurred(UINotificationFeedbackType.UINotificationFeedbackTypeSuccess)
     }
 
     override fun cancelVibration() {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds image style selection to AI image generation with prompt styling, introduces success haptics, and revamps AI bottom sheets with quality toggles, style carousel, and loading/progress animations.
> 
> - **AI Image Generation**:
>   - Add `ImageStyle` enum with display names, prompt affixes, and preview images.
>   - Change `generateImageFromDetails(details, cost)` to `generateImageFromDetails(details, cost, style)` and append style to prompts.
>   - Update details prompt wording; preserve model/size logic and fallback.
> - **State & Events**:
>   - Extend `AddEditDreamEvent`: `ClickGenerateAIImage(style, cost)`, `OnImageStyleChanged`, `TriggerVibrationSuccess`, `ResetNewImageGeneratedFlag`, `SetStartAnimation(Boolean)`.
>   - Extend `AddEditDreamState`: `imageStyle`, `isNewImageGenerated`, `startAnimation`.
>   - ViewModel wires new events/state, passes style to service, adds success flow and token consumption handling.
> - **UI/UX**:
>   - Overhaul bottom sheets (`ImageGenerationPopUp`, `DreamInterpretationPopUp`, `QuestionAIGenerationBottomSheet`): segmented quality/AI options, improved layout, rounded sheets.
>   - Image sheet adds style carousel (pager with previews) and passes selected style.
>   - Add timed loading progress bars and refined loading layouts across AI pages.
>   - Image page: entry animation on new image, success haptic trigger, and layout tweaks in `AIPage`.
>   - Update token/ad buttons visuals and copy (e.g., “Use X Dream Tokens”).
> - **Haptics**:
>   - Add `triggerVibrationSuccess()` to `VibratorUtil` (expect/actual for Android/iOS) and integrate into image generation success flow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a845f843efcb25a8e6e788a635af2edc22a235bc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->